### PR TITLE
Fix PDFService file pointer handling

### DIFF
--- a/src/services/pdf_service.py
+++ b/src/services/pdf_service.py
@@ -88,6 +88,9 @@ class PDFService:
                 file_content = file.read()
                 self._pdf_document = fitz.open(
                     stream=file_content, filetype="pdf")
+                # Reset pointer so downstream processors can read the file
+                if hasattr(file, "seek"):
+                    file.seek(0)
 
             self._total_pages = len(self._pdf_document)
 
@@ -110,8 +113,7 @@ class PDFService:
 
                 self.processor = PDFProcessor(
                     extraction_strategy=extraction_strategy,
-                    llm_api_key=self.llm_api_key,
-                    prompt_template=prompt
+                    llm_api_key=self.llm_api_key
                 )
             else:
                 self.processor = PDFProcessor(


### PR DESCRIPTION
## Summary
- reset file pointer after reading for PyMuPDF
- remove unused prompt_template parameter when creating `PDFProcessor`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68407496ffc88320ba97e3c1c1d7596f